### PR TITLE
Add QR code uri placeholder and update the otphp packge to v10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^7.2|^8.0",
         "yiisoft/yii2": ">=2.0.13",
         "spomky-labs/otphp": "^10.0"
     },
@@ -29,11 +29,6 @@
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "yiisoft/yii2-composer": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": "^8.0",
         "yiisoft/yii2": ">=2.0.13",
-        "spomky-labs/otphp": "^9.0"
+        "spomky-labs/otphp": "^10.0"
     },
     "autoload": {
         "psr-4": {
@@ -29,6 +29,11 @@
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "yiisoft/yii2-composer": true
         }
     }
 }

--- a/src/Otp.php
+++ b/src/Otp.php
@@ -57,6 +57,11 @@ class Otp extends BaseObject
     public $qrCodeUriTemplate = 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl={PROVISIONING_URI}';
 
     /**
+     * @var string
+     */
+    public $qrCodeUriPlaceholder = '{PROVISIONING_URI}';
+
+    /**
      * Generate an otp digits.
      *
      * @param string $secretKey the secret key use to generate an otp
@@ -104,7 +109,7 @@ class Otp extends BaseObject
             $instance->setParameter($param, $value);
         }
 
-        return $instance->getQrCodeUri($this->qrCodeUriTemplate);
+        return $instance->getQrCodeUri($this->qrCodeUriTemplate, $this->qrCodeUriPlaceholder);
     }
 
     /**


### PR DESCRIPTION
By the time of making this PR, there was a bug in the master branch of the main repository. The bug is that the function getQrCodeUri inside the Otp.php does use the mfa-generated secret to generate the QR code. 

I also updated the spomky-labs/otphp package to v10.